### PR TITLE
fix(DEC-4): Hinweis auf Alternativ-Kennzeichnung nur bei 100% Bio-Landwirtschaft

### DIFF
--- a/src/components/label_preview.rs
+++ b/src/components/label_preview.rs
@@ -426,8 +426,12 @@ pub fn LabelPreview(
                     div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
                         {t!("bio_hints.marketing_allowed").to_string()}
                     }
-                    div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
-                        {t!("bio_hints.alternative_marking").to_string()}
+                    // DEC-4: nur zulässig, wenn alle landwirtschaftlichen Zutaten bio sind
+                    // (keine erlaubte nicht-biologische Ausnahme in der Rezeptur).
+                    if conditionals.0().get("alternative_marking_allowed").unwrap_or(&false) == &true {
+                        div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
+                            {t!("bio_hints.alternative_marking").to_string()}
+                        }
                     }
                     // Monoprodukt aus Umstellbetrieb: "Bio" allowed + mandatory Umstellungshinweis (Zeile 7).
                     if conditionals.0().get("umstellbetrieb_hinweis").unwrap_or(&false) == &true {
@@ -474,8 +478,12 @@ pub fn LabelPreview(
                     div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
                         {t!("bio_hints.knospe_check_ok").to_string()}
                     }
-                    div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
-                        {t!("bio_hints.alternative_marking").to_string()}
+                    // DEC-4: nur zulässig, wenn alle landwirtschaftlichen Zutaten bio sind
+                    // (keine erlaubte nicht-biologische Ausnahme in der Rezeptur).
+                    if conditionals.0().get("alternative_marking_allowed").unwrap_or(&false) == &true {
+                        div { class: "mt-2 p-2 bg-info/30 text-base-content text-xs rounded",
+                            {t!("bio_hints.alternative_marking").to_string()}
+                        }
                     }
                 }
                 if conditionals.0().get("knospe_check_failed").unwrap_or(&false) == &true {

--- a/src/core.rs
+++ b/src/core.rs
@@ -342,6 +342,25 @@ fn calculate_erlaubte_ausnahme_bio_percentage(ingredients: &[Ingredient]) -> f64
     (ausnahme_amount / total_agricultural_amount) * 100.0
 }
 
+/// Whether the recipe contains at least one permitted non-organic agricultural
+/// ingredient (Annex 3 WBF / Bio Suisse Part III, e.g. Pektin).
+///
+/// Such a recipe is NOT 100% organic-agricultural, so only the per-ingredient
+/// *-marking is legally available; the blanket wordings ("Alle landwirtschaftlichen
+/// Zutaten stammen aus biologischer Landwirtschaft" / the "Bio-" prefix) would be
+/// untrue (DEC-4).
+fn has_erlaubte_ausnahme(ingredients: &[Ingredient]) -> bool {
+    ingredients
+        .iter()
+        .flat_map(|i| i.leaves())
+        .filter(|i| i.is_agricultural())
+        .any(|i| {
+            (i.erlaubte_ausnahme_bio.unwrap_or(false)
+                || i.erlaubte_ausnahme_knospe.unwrap_or(false))
+                && !i.is_bio_ch_compliant()
+        })
+}
+
 /// Determines if a product is a Monoprodukt (single agricultural ingredient)
 fn is_mono_product(ingredients: &[Ingredient]) -> bool {
     ingredients.iter()
@@ -1268,6 +1287,14 @@ impl Calculator {
 
         let mut validation_messages = HashMap::new();
         let mut conditionals = HashMap::new();
+
+        // DEC-4: the alternative marking wordings ("Alle landwirtschaftlichen Zutaten
+        // stammen aus biologischer Landwirtschaft" / "Bio-" prefix) are only truthful
+        // when every agricultural ingredient is organic. With a permitted non-organic
+        // exception in the recipe, only the per-ingredient *-marking is available.
+        if !has_erlaubte_ausnahme(&input.ingredients) {
+            conditionals.insert(String::from("alternative_marking_allowed"), true);
+        }
 
         // Calculate total amount first (needed for validations)
         let mut total_amount = input.ingredients.iter().map(|x| x.computed_amount()).sum();

--- a/src/core/tests/bio.rs
+++ b/src/core/tests/bio.rs
@@ -915,6 +915,111 @@ fn bio_check_pending_before_rezeptur_vollstaendig() {
     assert_eq!(c.get("bio_check_failed"), None);
 }
 
+// =============================================================================
+// Group — DEC-4: alternative_marking_allowed
+//
+// The blanket wordings («Alle landwirtschaftlichen Zutaten stammen aus
+// biologischer Landwirtschaft» / «Bio-» prefix) are only truthful when EVERY
+// agricultural ingredient is organic. A permitted non-organic exception
+// (Anhang 3 WBF, e.g. Pektin) leaves only the per-ingredient *-marking.
+// =============================================================================
+
+#[test]
+fn alternative_marking_allowed_when_all_agricultural_are_bio() {
+    let mut calculator = setup_simple_calculator();
+    calculator.registerRuleDefs(vec![RuleDef::Bio_ShowBioSachbezeichnung]);
+    let input = InputBuilder::new()
+        .vollstaendig()
+        .ingredient(IngredientBuilder::new_agri("Himbeeren", 500.0).bio_ch().build())
+        .ingredient(IngredientBuilder::new_agri("Zucker", 500.0).bio_ch().build())
+        .build();
+    let output = calculator.execute(input);
+    let c = &output.conditional_elements;
+
+    assert_eq!(c.get("bio_check_ok"), Some(&true));
+    assert_eq!(c.get("alternative_marking_allowed"), Some(&true));
+}
+
+#[test]
+fn alternative_marking_suppressed_with_erlaubte_ausnahme_bio() {
+    // Ticket example: Konfitüre with 5 g Pektin as a permitted non-organic
+    // agricultural ingredient. Recipe still qualifies for Bio, but only the
+    // *-marking per ingredient is allowed.
+    let mut calculator = setup_simple_calculator();
+    calculator.registerRuleDefs(vec![RuleDef::Bio_ShowBioSachbezeichnung]);
+    let input = InputBuilder::new()
+        .vollstaendig()
+        .ingredient(IngredientBuilder::new_agri("Himbeeren", 500.0).bio_ch().build())
+        .ingredient(IngredientBuilder::new_agri("Zucker", 500.0).bio_ch().build())
+        .ingredient(IngredientBuilder::new_agri("Pektin", 5.0).erlaubte_ausnahme_bio().build())
+        .build();
+    let output = calculator.execute(input);
+    let c = &output.conditional_elements;
+
+    // The positive verdict must remain — only the alternative-wording hint goes.
+    assert_eq!(c.get("bio_check_ok"), Some(&true), "Rezeptur erfüllt die Bio-Anforderungen weiterhin");
+    assert_eq!(c.get("alternative_marking_allowed"), None);
+}
+
+#[test]
+fn alternative_marking_suppressed_with_erlaubte_ausnahme_knospe() {
+    // Same rule in the Knospe environment (ticket: Bio-V *and* Knospe).
+    let mut calculator = setup_simple_calculator();
+    calculator.registerRuleDefs(vec![
+        RuleDef::Knospe_ShowBioSuisseLogo,
+        RuleDef::Knospe_100_Percent_CH_NoOrigin,
+    ]);
+    let input = InputBuilder::new()
+        .vollstaendig()
+        .ingredient(IngredientBuilder::new_agri("Himbeeren", 995.0).bio().origin(Country::CH).build())
+        .ingredient(IngredientBuilder::new_agri("Pektin", 5.0).origin(Country::CH).erlaubte_ausnahme_knospe().build())
+        .build();
+    let output = calculator.execute(input);
+    let c = &output.conditional_elements;
+
+    assert_eq!(c.get("knospe_check_ok"), Some(&true), "Rezeptur erfüllt die Knospe-Anforderungen weiterhin");
+    assert_eq!(c.get("alternative_marking_allowed"), None);
+}
+
+#[test]
+fn alternative_marking_allowed_when_exception_ingredient_is_also_bio() {
+    // Flag set but the ingredient IS bio-certified: it is not actually a
+    // non-organic exception, so the blanket wording stays truthful.
+    let mut calculator = setup_simple_calculator();
+    calculator.registerRuleDefs(vec![RuleDef::Bio_ShowBioSachbezeichnung]);
+    let input = InputBuilder::new()
+        .vollstaendig()
+        .ingredient(IngredientBuilder::new_agri("Himbeeren", 995.0).bio_ch().build())
+        .ingredient(IngredientBuilder::new_agri("Pektin", 5.0).bio_ch().erlaubte_ausnahme_bio().build())
+        .build();
+    let output = calculator.execute(input);
+    let c = &output.conditional_elements;
+
+    assert_eq!(c.get("alternative_marking_allowed"), Some(&true));
+}
+
+#[test]
+fn alternative_marking_suppressed_for_nested_erlaubte_ausnahme() {
+    // The exception sits inside a composite — leaves() must find it.
+    let mut calculator = setup_simple_calculator();
+    calculator.registerRuleDefs(vec![RuleDef::Bio_ShowBioSachbezeichnung]);
+    let fuellung = IngredientBuilder::new_agri("Füllung", 500.0)
+        .children(vec![
+            IngredientBuilder::new_agri("Aprikosen", 495.0).bio_ch().build(),
+            IngredientBuilder::new_agri("Pektin", 5.0).erlaubte_ausnahme_bio().build(),
+        ])
+        .build();
+    let input = InputBuilder::new()
+        .vollstaendig()
+        .ingredient(IngredientBuilder::new_agri("Zucker", 500.0).bio_ch().build())
+        .ingredient(fuellung)
+        .build();
+    let output = calculator.execute(input);
+    let c = &output.conditional_elements;
+
+    assert_eq!(c.get("alternative_marking_allowed"), None);
+}
+
 #[test]
 fn bio_check_ok_when_vollstaendig_and_qualifies() {
     // Checked + >= 95% Bio-CH + no recipe issues → ok.


### PR DESCRIPTION
Behebt [DEC-4](https://rbrand.youtrack.cloud/issue/DEC-4).

## Problem
Enthält die Rezeptur eine erlaubte nicht-biologische landwirtschaftliche Zutat (z.B. Pektin), erscheint nach «Rezeptur prüfen» trotzdem noch der blaue Hinweis mit den beiden Alternativvarianten. Dann ist aber nur noch die *-Kennzeichnung pro Zutat zulässig — die pauschalen Wordings («Alle landwirtschaftlichen Zutaten stammen aus biologischer Landwirtschaft» / Präfix «Bio-») wären unwahr.

## Lösung
- Neues Conditional `alternative_marking_allowed`, gesetzt wenn die Rezeptur **keine** erlaubte nicht-bio Ausnahme enthält (Helper `has_erlaubte_ausnahme` in `src/core.rs`).
- Der Hinweis hing bisher allein am jeweiligen `*_check_ok`-Flag. Jetzt zusätzlich am neuen Conditional, in beiden Umgebungen (Bio-V und Knospe).
- Die positive Meldung «erfüllt die Anforderungen» bleibt in beiden Fällen erhalten.

Berücksichtigt sowohl `erlaubte_ausnahme_bio` als auch `erlaubte_ausnahme_knospe`, und über `leaves()` auch Ausnahmen innerhalb zusammengesetzter Zutaten.

## Tests
5 neue Fälle in `src/core/tests/bio.rs`:
- Bio-V mit / ohne Ausnahme
- Knospe mit Ausnahme
- Ausnahme innerhalb einer zusammengesetzten Zutat
- Abgrenzung: Häkchen gesetzt, Zutat aber bio-zertifiziert → Hinweis bleibt zulässig

Gegenprobe ohne den Guard: die drei Suppression-Tests schlagen fehl. Suite: 246 grün (vorher 241).

## Verifikation im Browser
Zusätzlich zu den Unit-Tests wurde das Ticket-Beispiel (Konfitüre: Himbeere 500 g Bio, Zucker 500 g Bio, Pektin 5 g erlaubte Ausnahme) über WebDriver gegen den laufenden `dx serve` geprüft, in beiden Umgebungen und je mit und ohne Pektin:

| Fall | Hinweis sichtbar | positive Meldung |
|---|---|---|
| Bio-V mit Pektin | nein | ja |
| Bio-V ohne Pektin | ja | ja |
| Knospe mit Pektin | nein | ja |
| Knospe ohne Pektin | ja | ja |
